### PR TITLE
[Seek][Improvement] Fixed an conditional statement when it used query…

### DIFF
--- a/src/seek.js
+++ b/src/seek.js
@@ -409,7 +409,7 @@
 		var results = [], newSelector, oldId, newId, newContext = context, attrValues = [], tokens, token, i = 0, cnt = 0,
 			changeSelector = context.nodeType === 1 && context.nodeName.toLowerCase() !== "object";
 
-		if ( !selector || selector === "" ) {
+		if ( !selector ) {
 			return [];
 		}
 


### PR DESCRIPTION
I found using the pre-processing tool, It seems to be unnecessary even though I think.

Condition 'selector === ""' is always false at this point
because the false branch of the condition '!selector' has been taken.