### PR TITLE
[Seek][Improvement] Fixed unexpected global variable.

### DIFF
--- a/src/seek.js
+++ b/src/seek.js
@@ -130,7 +130,7 @@
 		try {
 			for ( ; i < length ; i++ ) {
 				result = querySelector( contexts[ i ] , selector );
-				if ( result && result.length > 0 ) {
+				if ( result.length > 0 ) {
 					push.apply( results, slice.call( result, 0 ) );
 				}
 			}


### PR DESCRIPTION
The 'results' variable seems to be an unexpected global variable.
This issue may cause unexpected behavior when other implementations are added in the future.
It would be nice to add ',' at the end of the line.